### PR TITLE
Fixes wscript to build, install bindings without tests

### DIFF
--- a/wscript
+++ b/wscript
@@ -262,6 +262,16 @@ def build(bld):
                   defines         = defines + ['LILV_INTERNAL'])
         autowaf.use_lib(bld, obj, 'SERD SORD SRATOM LV2')
 
+    # Python bindings
+    if bld.is_defined('LILV_PYTHON'):
+        # Copy Python bindings to build directory
+        bld(features     = 'subst',
+            is_copy      = True,
+            source       = 'bindings/python/lilv.py',
+            target       = 'lilv.py',
+            install_path = '${PYTHONDIR}')
+
+    # Tests
     if bld.env.BUILD_TESTS:
         test_libs      = lib
         test_cflags    = ['']
@@ -350,13 +360,6 @@ def build(bld):
         autowaf.use_lib(bld, obj, 'SERD SORD SRATOM LV2')
 
         if bld.is_defined('LILV_PYTHON'):
-            # Copy Python bindings to build directory
-            bld(features     = 'subst',
-                is_copy      = True,
-                source       = 'bindings/python/lilv.py',
-                target       = 'lilv.py',
-                install_path = '${PYTHONDIR}')
-
             # Copy Python unittest files
             for i in [ 'test_api.py' ]:
                 bld(features     = 'subst',


### PR DESCRIPTION
Without this change the wscript, even when configured with --bindings, does not build or install the Python bindings as it is conditional on bld.env.BUILD_TESTS.

This change moves the bindings build rule out of the bld.env.BUILD_TESTS block, making it solely conditional on bld.is_defined('LILV_PYTHON').