### PR TITLE
fix error on creating the pluign state symbolic links

### DIFF
--- a/src/state.c
+++ b/src/state.c
@@ -1039,6 +1039,10 @@ lilv_state_make_links(const LilvState* state, const char* dir)
 				// Make a link in the link directory to external file
 				char* lpath = lilv_find_free_path(pat, link_exists, pm->abs);
 				if (!lilv_path_exists(lpath, NULL)) {
+				        // Remove the link if it happens to exist but it is dangling.
+					unlink(lpath);
+					
+					// Create the link to external file.
 					lilv_symlink(pm->abs, lpath);
 				}
 


### PR DESCRIPTION
If the external file was moved into another place and the user wants to select it again, it will not be able to set it because the symbolic link to the previous location is danging, and the creation of the new symbolic link fails.  Here are some of my logs from Ardour:

lilv_symlink(): error: Failed to link /home/iurie/Desktop/Geontime/ideas/Seductive Moment/Seductive Moment/externals/kick01.wav => /home/iurie/Desktop/Geontime/instruments/Drums/kick01.wav (File exists)
actually writing state to /home/iurie/Desktop/Geontime/ideas/Seductive Moment/Seductive Moment/Seductive Moment.tmp
renaming state to /home/iurie/Desktop/Geontime/ideas/Seductive Moment/Seductive Moment/Seductive Moment.ardour
