### PR TITLE
Add functions to query supported features of Plugin UIs.

### DIFF
--- a/lilv/lilv.h
+++ b/lilv/lilv.h
@@ -1839,7 +1839,7 @@ lilv_ui_get_binary_uri(const LilvUI* ui);
 */
 LILV_API bool
 lilv_ui_has_feature(const LilvUI* ui,
-		    const LilvNode*   feature);
+                    const LilvNode*   feature);
 
 /**
    Get the LV2 Features supported (required or optionally) by a Plugin UI.

--- a/lilv/lilv.h
+++ b/lilv/lilv.h
@@ -1833,6 +1833,53 @@ LILV_API const LilvNode*
 lilv_ui_get_binary_uri(const LilvUI* ui);
 
 /**
+   Return whether a feature is supported by a Plugin UI.
+   This will return true if the feature is an optional or required feature
+   of the UI.
+*/
+LILV_API bool
+lilv_ui_has_feature(const LilvUI* ui,
+		    const LilvNode*   feature);
+
+/**
+   Get the LV2 Features supported (required or optionally) by a Plugin UI.
+   A feature is "supported" by an UI if it is required OR optional.
+
+   Since required features have special rules the host must obey, this function
+   probably shouldn't be used by normal hosts.  Using lilv_ui_get_optional_features()
+   and lilv_ui_get_required_features() separately is best in most cases.
+
+   Returned value must be freed by caller with lilv_nodes_free().
+*/
+LILV_API LilvNodes*
+lilv_ui_get_supported_features(const LilvUI* ui);
+
+/**
+   Get the LV2 Features required by a Plugin UI.
+   If a feature is required by an UI, hosts MUST NOT use the UI if they do not
+   understand (or are unable to support) that feature.
+
+   All values returned here MUST be passed to the UI's instantiate method
+   (along with data, if necessary, as defined by the feature specification)
+   or UI instantiation will fail.
+
+   Return value must be freed by caller with lilv_nodes_free().
+*/
+LILV_API LilvNodes*
+lilv_ui_get_required_features(const LilvUI* ui);
+
+/**
+   Get the LV2 Features optionally supported by a Plugin UI.
+   Hosts MAY ignore optional UI features for whatever reasons.  UIs
+   MUST operate (at least somewhat) if they are instantiated without being
+   passed optional features.
+
+   Return value must be freed by caller with lilv_nodes_free().
+*/
+LILV_API LilvNodes*
+lilv_ui_get_optional_features(const LilvUI* ui);
+
+/**
    @}
    @}
 */

--- a/lilv/lilvmm.hpp
+++ b/lilv/lilvmm.hpp
@@ -158,6 +158,10 @@ struct UI {
 	           const LilvNode*,     container_type,
 	           const LilvNode**,    ui_type);*/
 	LILV_WRAP1(bool, ui, is_a, const LilvNode*, class_uri);
+	LILV_WRAP1(bool, ui, has_feature, Node, feature_uri);
+	LILV_WRAP0(Nodes, ui, get_supported_features);
+	LILV_WRAP0(Nodes, ui, get_required_features);
+	LILV_WRAP0(Nodes, ui, get_optional_features);
 
 	const LilvUI* me;
 };

--- a/src/ui.c
+++ b/src/ui.c
@@ -112,7 +112,7 @@ lilv_ui_get_binary_uri(const LilvUI* ui)
 
 LILV_API bool
 lilv_ui_has_feature(const LilvUI* ui,
-                        const LilvNode*   feature)
+                    const LilvNode*   feature)
 {
 	const SordNode* predicates[] = { ui->world->uris.lv2_requiredFeature,
 	                                 ui->world->uris.lv2_optionalFeature,

--- a/src/ui.c
+++ b/src/ui.c
@@ -109,3 +109,49 @@ lilv_ui_get_binary_uri(const LilvUI* ui)
 {
 	return ui->binary_uri;
 }
+
+LILV_API bool
+lilv_ui_has_feature(const LilvUI* ui,
+                        const LilvNode*   feature)
+{
+	const SordNode* predicates[] = { ui->world->uris.lv2_requiredFeature,
+	                                 ui->world->uris.lv2_optionalFeature,
+	                                 NULL };
+
+	for (const SordNode** pred = predicates; *pred; ++pred) {
+		if (lilv_world_ask_internal(
+			    ui->world, ui->uri->node, *pred, feature->node)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+LILV_API LilvNodes*
+lilv_ui_get_supported_features(const LilvUI* ui)
+{
+	LilvNodes* optional = lilv_ui_get_optional_features(ui);
+	LilvNodes* required = lilv_ui_get_required_features(ui);
+	LilvNodes* result   = lilv_nodes_merge(optional, required);
+	lilv_nodes_free(optional);
+	lilv_nodes_free(required);
+	return result;
+}
+
+LILV_API LilvNodes*
+lilv_ui_get_optional_features(const LilvUI* ui)
+{
+	return lilv_world_find_nodes_internal(ui->world,
+	                                      ui->uri->node,
+	                                      ui->world->uris.lv2_optionalFeature,
+	                                      NULL);
+}
+
+LILV_API LilvNodes*
+lilv_ui_get_required_features(const LilvUI* ui)
+{
+	return lilv_world_find_nodes_internal(ui->world,
+	                                      ui->uri->node,
+	                                      ui->world->uris.lv2_requiredFeature,
+	                                      NULL);
+}


### PR DESCRIPTION
Hi,

I couldn't figure out how to query the required/optional features of a Plugin UI, so the host knows in advance, which UIs it can't support. Please tell me, if I'm just missing something...

I hacked something up, which happens to Just Work(tm).
Basically just a copy'n'paste and a s/plugin/ui/ of the related lilv_plugin_* functions.

Cheers,
-Ben
