### PR TITLE
Fix building with --dyn-manifest in MSVC

### DIFF
--- a/src/world.c
+++ b/src/world.c
@@ -556,7 +556,7 @@ lilv_world_load_dyn_manifest(LilvWorld*      world,
 			continue;
 		}
 
-		LilvDynManifest* desc = malloc(sizeof(LilvDynManifest));
+		LilvDynManifest* desc = (LilvDynManifest*)malloc(sizeof(LilvDynManifest));
 		desc->bundle = lilv_node_new_from_node(world, bundle_node);
 		desc->lib    = lib;
 		desc->handle = handle;


### PR DESCRIPTION
Fixes this error:
```
...\lilv\src\world.c(559): error C2440: 'initializing': cannot convert from 'void *' to 'LilvDynManifest *'
...\lilv\src\world.c(559): note: Conversion from 'void*' to pointer to non-'void' requires an explicit cast
```