### PR TITLE
Avoid memory leak when dynmanifest returns no plugin subjects

### DIFF
--- a/src/dynmanifest.c
+++ b/src/dynmanifest.c
@@ -1,0 +1,40 @@
+/* 
+  Authored in 2019 Michael Fisher <mfisher31@gmail.com>
+  
+  Permission to use, copy, modify, and/or distribute this software for any
+  purpose with or without fee is hereby granted, provided that the above
+  copyright notice and this permission notice appear in all copies.
+
+  THIS SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+#ifdef LILV_DYN_MANIFEST
+
+#ifdef __APPLE__
+#   define _DARWIN_C_SOURCE 1  /* for flock */
+#endif
+
+#include "lilv_internal.h"
+
+void
+lilv_dyn_manifest_free (LilvDynManifest* dynmanifest)
+{
+	typedef int (*CloseFunc)(LV2_Dyn_Manifest_Handle);
+	CloseFunc close_func = (CloseFunc)lilv_dlfunc(dynmanifest->lib,
+												"lv2_dyn_manifest_close");
+	if (close_func) {
+		close_func(dynmanifest->handle);
+	}
+
+	dlclose(dynmanifest->lib);
+	lilv_node_free(dynmanifest->bundle);
+	free(dynmanifest);
+}
+
+#endif

--- a/src/lilv_internal.h
+++ b/src/lilv_internal.h
@@ -423,6 +423,8 @@ lilv_dlfunc(void* handle, const char* symbol)
 
 #ifdef LILV_DYN_MANIFEST
 static const LV2_Feature* const dman_features = { NULL };
+void
+lilv_dyn_manifest_free (LilvDynManifest* dynmanifest);
 #endif
 
 #define LILV_ERROR(str)       fprintf(stderr, "%s(): error: " str, \

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -100,16 +100,7 @@ lilv_plugin_free(LilvPlugin* plugin)
 {
 #ifdef LILV_DYN_MANIFEST
 	if (plugin->dynmanifest && --plugin->dynmanifest->refs == 0) {
-		typedef int (*CloseFunc)(LV2_Dyn_Manifest_Handle);
-		CloseFunc close_func = (CloseFunc)lilv_dlfunc(plugin->dynmanifest->lib,
-		                                              "lv2_dyn_manifest_close");
-		if (close_func) {
-			close_func(plugin->dynmanifest->handle);
-		}
-
-		dlclose(plugin->dynmanifest->lib);
-		lilv_node_free(plugin->dynmanifest->bundle);
-		free(plugin->dynmanifest);
+		lilv_dyn_manifest_free(plugin->dynmanifest);
 	}
 #endif
 

--- a/src/world.c
+++ b/src/world.c
@@ -619,7 +619,7 @@ lilv_world_load_dyn_manifest(LilvWorld*      world,
 			lilv_world_add_plugin(world, plug, manifest, desc, bundle_node);
 		}
 		if (desc->refs == 0) {
-			free(desc);
+			lilv_dyn_manifest_free(desc);
 		}
 		sord_iter_free(p);
 		sord_free(plugins);

--- a/wscript
+++ b/wscript
@@ -250,6 +250,8 @@ def build(bld):
                   cflags          = libflags,
                   lib             = lib,
                   uselib          = 'SERD SORD SRATOM LV2')
+        if bld.env.LILV_DYN_MANIFEST:
+            obj.source.append('src/dynmanifest.c')
 
     # Static library
     if bld.env.BUILD_STATIC:
@@ -263,6 +265,8 @@ def build(bld):
                   install_path    = '${LIBDIR}',
                   defines         = defines + ['LILV_INTERNAL'],
                   uselib          = 'SERD SORD SRATOM LV2')
+        if bld.env.LILV_DYN_MANIFEST:
+            obj.source.append('src/dynmanifest.c')
 
     # Python bindings
     if bld.is_defined('LILV_PYTHON'):


### PR DESCRIPTION
This adds an internal function to free LilvDynManifest in a consistent way.  world.c was just calling `free(...)` on it after loading the library & getting no plugins from the `lv2_dyn_manifest_get_subjects` handler.