### PR TITLE
Fix default LV2 paths on cross-compiled Windows builds

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -187,7 +187,11 @@ if default_lv2_path == ''
     default_lv2_path = ':'.join(['~/.lv2', '/boot/common/add-ons/lv2'])
 
   elif host_machine.system() == 'windows'
-    lv2_dirs = ['%%APPDATA%%\\\\LV2', '%%COMMONPROGRAMFILES%%\\\\LV2']
+    if build_machine.system() == 'windows'
+      lv2_dirs = ['%%APPDATA%%\\\\LV2', '%%COMMONPROGRAMFILES%%\\\\LV2']
+    else
+      lv2_dirs = ['%APPDATA%\\\\LV2', '%COMMONPROGRAMFILES%\\\\LV2']
+    endif
     default_lv2_path = ';'.join(lv2_dirs)
 
   else


### PR DESCRIPTION
The default LV2 paths for Windows in `meson.build` cannot have the "%" escaped by doubling it ("%%") when cross-compiling from a non-Windows machine, i.e. cross-compiling for Windows from Linux using MinGW.

When the build machine is Windows, "%%" converts to "%" when passed as command-line arguments to the compiler, but on a non-Windows build machine, "%%" remains as is and breaks the ability for `zix_expand_environment_strings` to expand the environment strings in the `LILV_DEFAULT_LV2_PATH` macro.

## Before this PR:
### Cross-compiled MinGW:
```bash
$ strings vcpkg/installed/x64-mingw-static/lib/liblilv-0.a | grep APPDATA
%%APPDATA%%\LV2;%%COMMONPROGRAMFILES%%\LV2
```
(Notice the double "%" - `zix_expand_environment_strings` fails to expand the environment variables, causing to lilv fail to discover LV2 plugins when I test it via Wine)

### Native Windows:
```cmd
$ ./strings64.exe vcpkg/installed/x64-windows/bin/lilv-0.dll | grep APPDATA
%APPDATA%\LV2;%COMMONPROGRAMFILES%\LV2
```
(The double "%" was converted to single "%" and everything works as expected)

## After this PR:
### Cross-compiled MinGW:
```bash
$ strings vcpkg/installed/x64-mingw-static/lib/liblilv-0.a | grep APPDATA
%APPDATA%\LV2;%COMMONPROGRAMFILES%\LV2
```
(No more double "%" - lilv successfully discovers LV2 plugins when I test it via Wine)

### Native Windows:
```cmd
$ ./strings64.exe vcpkg/installed/x64-windows/bin/lilv-0.dll | grep APPDATA
%APPDATA%\LV2;%COMMONPROGRAMFILES%\LV2
```
(Everything continues to work as expected)

